### PR TITLE
Fix - empty activity list when course include Label resources

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,7 @@ class repository_activitylinks extends repository {
         $ret['nologin'] = true;
         $ret['list'] = array();
 
-        if (!$courseid = get_courseid_from_context($this->context)) {
+        if (!$courseid = $this->context->get_course_context(false)->instanceid) {
             return $ret;
         }
 
@@ -43,7 +43,7 @@ class repository_activitylinks extends repository {
 
         $list = array();
         foreach ($modinfo->get_cms() as $cm) {
-            if (!$cm->uservisible) {
+            if (!$cm->uservisible || $cm->modname == 'label') {
                 continue;
             }
 

--- a/lib.php
+++ b/lib.php
@@ -43,7 +43,7 @@ class repository_activitylinks extends repository {
 
         $list = array();
         foreach ($modinfo->get_cms() as $cm) {
-            if (!$cm->uservisible || $cm->modname == 'label') {
+            if (!$cm->uservisible or !$cm->has_view()) {
                 continue;
             }
 


### PR DESCRIPTION
- minor fix/migration of deprecated function get_courseid_from_context() call with get_course_context()
